### PR TITLE
Remove spaces from font name in add_ls

### DIFF
--- a/microtype.dtx
+++ b/microtype.dtx
@@ -9741,11 +9741,15 @@ time will almost certainly lead to undesired results. Have your choice!}%
 %<*luafile>
 local function add_ls(k)
   local f = tex.fontname(font.current())
+  f = f:gsub('^"', ""):gsub('"$', "") -- remove surrounding quotation marks
   local spec,size = match(f,'^(.+)( at .+)$')
   if not spec then spec = f end
   local a,b,c = match(spec,'^([^:]+):?([^:]*):?(.*)$')
   local ls = "kernfactor=" .. k/1000 .. ';'
   microtype.sprint(a..':')
+  if (a == "name") then
+    b = b:gsub("%s+", "") -- remove space from font name
+  end
   if (a == "name" or a == "file") then
     microtype.sprint(b..':'..ls..c)
   else


### PR DESCRIPTION
may be a fix for #16

I tested this with a file name with the file below (font installed locally) with the extracted package.  Not sure if this is exhaustive.

There were two changes:

- When the font name contains spaces, `tex.fontname` adds surrounding quotation marks around its return value; these are removed.
- The font name should apparently not have spaces with fontspec 2.9b, but filenames may.

```
\documentclass{article}
\usepackage{unicode-math}

% \setmainfont[Ligatures={TeX}]{Carlito} % works
\setmainfont[Ligatures={TeX}]{Libertinus Serif} % did not work, but works now
\setmonofont{Inconsolatazi4-Regular.otf}[Scale=MatchLowercase] % unharmed 

% The following path only works (a) with fontspec 2.9b (b) if the file is locally installed! (Added to make sure it still works.)
\setmonofont{Cousine Regular Nerd Font Complete Mono.ttf}[Scale=MatchLowercase]

\usepackage[]{microtype}

\begin{document}

Kaffee\textls{kanne}
\texttt{Kaffee\textls{kanne}}

\end{document}

```

